### PR TITLE
refactor: topic field — GONE from the bot!

### DIFF
--- a/src/common/dto/therapyRequest.dto.ts
+++ b/src/common/dto/therapyRequest.dto.ts
@@ -23,10 +23,9 @@ export type TherapyRequestDto = {
   accepted: boolean
   clientGender?: THERAPY_REQUEST_CLIENT_GENDER
   requestCategory?: THERAPY_REQUEST_CATEGORY
-  topic?: string
   analyticsReviewRequired?: boolean
   analyticsInference?: Record<
-    "clientGender" | "requestCategory" | "topic",
+    "clientGender" | "requestCategory",
     {
       value: string
       confidence: number


### PR DESCRIPTION
The API dropped topic. The bot held on. Not anymore. One DTO. Two lines. Clean.

Moving on!