### PR TITLE
feat: bot notifications — CLICKABLE. FINALLY!

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -28,5 +28,5 @@ module.exports = {
       },
     },
   },
-  ignorePatterns: ['global.d.ts'],
+  ignorePatterns: ['global.d.ts', '**/*.test.ts', '**/*.spec.ts'],
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "restart:node": "npm run build && npm run start",
     "restart:dev": "tsx ./src",
     "dev": "nodemon",
+    "test": "node --import tsx --test **/*.test.ts",
     "lint": "eslint --fix-dry-run ./src"
   },
   "author": "",

--- a/src/api/dto/createNotification.dto.ts
+++ b/src/api/dto/createNotification.dto.ts
@@ -1,5 +1,6 @@
 import { NOTIFICATION_TYPES } from "@/common/enums/notificationTypes"
 import { ROLES } from "@/common/enums/roles"
+import { NotificationMessageEntity } from "@/common/types/notificationMessageEntity"
 
 export type CreateNotificationDto = {
   startsAt?: string
@@ -7,5 +8,6 @@ export type CreateNotificationDto = {
   roles: Array<ROLES>
   title?: string
   message: string
+  messageEntities?: Array<NotificationMessageEntity>
   type: NOTIFICATION_TYPES
 }

--- a/src/common/dto/notification.dto.ts
+++ b/src/common/dto/notification.dto.ts
@@ -1,6 +1,7 @@
 import { NOTIFICATION_STATUSES } from "@/common/enums/notificationStatuses"
 import { NOTIFICATION_TYPES } from "@/common/enums/notificationTypes"
 import { ROLES } from "@/common/enums/roles"
+import { NotificationMessageEntity } from "@/common/types/notificationMessageEntity"
 
 export type NotificationDto = {
   _id: string
@@ -11,6 +12,7 @@ export type NotificationDto = {
   finishAt?: string
   title?: string
   message?: string
+  messageEntities?: Array<NotificationMessageEntity>
 
   roles: Array<ROLES>
   recipients: Array<string>

--- a/src/common/types/notificationMessageEntity.ts
+++ b/src/common/types/notificationMessageEntity.ts
@@ -1,0 +1,13 @@
+export type NotificationMessageEntity =
+  | {
+      type: "url"
+      offset: number
+      length: number
+    }
+  | {
+      type: "text_link"
+      offset: number
+      length: number
+      url: string
+    }
+

--- a/src/common/utils/isValidLinkUrl.ts
+++ b/src/common/utils/isValidLinkUrl.ts
@@ -1,0 +1,8 @@
+export function isValidLinkUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
+}

--- a/src/common/utils/notificationMessageEntities.ts
+++ b/src/common/utils/notificationMessageEntities.ts
@@ -1,0 +1,56 @@
+import type { MessageEntity } from "@grammyjs/types"
+import { NotificationMessageEntity } from "@/common/types/notificationMessageEntity"
+import { isValidLinkUrl } from "./isValidLinkUrl"
+
+function hasValidRange(entity: MessageEntity, message: string): boolean {
+  return (
+    Number.isInteger(entity.offset) &&
+    Number.isInteger(entity.length) &&
+    entity.offset >= 0 &&
+    entity.length > 0 &&
+    entity.offset + entity.length <= message.length
+  )
+}
+
+export function sanitizeNotificationMessageEntities(
+  message = "",
+  entities: Array<MessageEntity | NotificationMessageEntity> = []
+): Array<NotificationMessageEntity> {
+  return entities.reduce<Array<NotificationMessageEntity>>((result, entity) => {
+    if (!hasValidRange(entity, message)) {
+      return result
+    }
+
+    if (entity.type === "text_link" && isValidLinkUrl(entity.url)) {
+      result.push({
+        type: "text_link",
+        offset: entity.offset,
+        length: entity.length,
+        url: entity.url,
+      })
+    }
+
+    if (entity.type === "url") {
+      const url = message.slice(entity.offset, entity.offset + entity.length)
+      if (isValidLinkUrl(url)) {
+        result.push({
+          type: "url",
+          offset: entity.offset,
+          length: entity.length,
+        })
+      }
+    }
+
+    return result
+  }, [])
+}
+
+export function offsetNotificationMessageEntities(
+  entities: Array<NotificationMessageEntity>,
+  offset: number
+): Array<NotificationMessageEntity> {
+  return entities.map((entity) => ({
+    ...entity,
+    offset: entity.offset + offset,
+  }))
+}

--- a/src/common/utils/notificationMessageLinks.test.ts
+++ b/src/common/utils/notificationMessageLinks.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import {
+  offsetNotificationMessageEntities,
+  sanitizeNotificationMessageEntities,
+} from "./notificationMessageEntities"
+import { parseNotificationMessageLinks } from "./parseNotificationMessageLinks"
+
+describe("notification message links", () => {
+  it("parses multiple markdown fallback links", () => {
+    const result = parseNotificationMessageLinks(
+      "check [one](https://a.com) | [two](https://b.com)"
+    )
+
+    assert.equal(result.text, "check one | two")
+    assert.deepEqual(result.entities, [
+      { type: "text_link", offset: 6, length: 3, url: "https://a.com" },
+      { type: "text_link", offset: 12, length: 3, url: "https://b.com" },
+    ])
+  })
+
+  it("supports balanced parentheses inside markdown fallback urls", () => {
+    const url = "https://en.wikipedia.org/wiki/Foo_(bar)"
+    const result = parseNotificationMessageLinks(`[wiki](${url})`)
+
+    assert.equal(result.text, "wiki")
+    assert.deepEqual(result.entities, [
+      { type: "text_link", offset: 0, length: 4, url },
+    ])
+  })
+
+  it("preserves invalid and unfinished markdown links as plain text", () => {
+    const message =
+      "bad [link](javascript:alert(1)) and [open](https://example.com"
+    const result = parseNotificationMessageLinks(message)
+
+    assert.equal(result.text, message)
+    assert.deepEqual(result.entities, [])
+  })
+
+  it("leaves messages without links unchanged", () => {
+    const result = parseNotificationMessageLinks("plain * _ ! text")
+
+    assert.equal(result.text, "plain * _ ! text")
+    assert.deepEqual(result.entities, [])
+  })
+
+  it("sanitizes telegram-native link entities", () => {
+    const result = sanitizeNotificationMessageEntities("Текст и ссылка", [
+      { type: "text_link", offset: 8, length: 6, url: "https://example.com" },
+      { type: "url", offset: 0, length: 5 },
+      { type: "bold", offset: 0, length: 5 },
+      { type: "text_link", offset: 8, length: 6, url: "javascript:alert(1)" },
+      { type: "text_link", offset: 99, length: 6, url: "https://example.com" },
+    ])
+
+    assert.deepEqual(result, [
+      { type: "text_link", offset: 8, length: 6, url: "https://example.com" },
+    ])
+  })
+
+  it("keeps valid raw url entities", () => {
+    const message = "open https://example.com"
+    const result = sanitizeNotificationMessageEntities(message, [
+      { type: "url", offset: 5, length: 19 },
+    ])
+
+    assert.deepEqual(result, [{ type: "url", offset: 5, length: 19 }])
+  })
+
+  it("offsets entities after the title prefix", () => {
+    const result = offsetNotificationMessageEntities(
+      [{ type: "text_link", offset: 8, length: 6, url: "https://example.com" }],
+      "Заголовок:\r\n\r\n".length
+    )
+
+    assert.deepEqual(result, [
+      { type: "text_link", offset: 22, length: 6, url: "https://example.com" },
+    ])
+  })
+})
+

--- a/src/common/utils/parseNotificationMessageLinks.ts
+++ b/src/common/utils/parseNotificationMessageLinks.ts
@@ -1,0 +1,81 @@
+import { NotificationMessageEntity } from "@/common/types/notificationMessageEntity"
+import { isValidLinkUrl } from "./isValidLinkUrl"
+
+export type ParsedNotificationMessage = {
+  text: string
+  entities: Array<NotificationMessageEntity>
+}
+
+export function parseNotificationMessageLinks(
+  message = ""
+): ParsedNotificationMessage {
+  const entities: Array<NotificationMessageEntity> = []
+  let text = ""
+  let index = 0
+
+  while (index < message.length) {
+    const linkStart = message.indexOf("[", index)
+
+    if (linkStart === -1) {
+      text += message.slice(index)
+      break
+    }
+
+    text += message.slice(index, linkStart)
+
+    const labelEnd = message.indexOf("]", linkStart + 1)
+    if (labelEnd === -1) {
+      text += message.slice(linkStart)
+      break
+    }
+
+    const label = message.slice(linkStart + 1, labelEnd)
+    if (!label || /[\r\n]/.test(label) || message[labelEnd + 1] !== "(") {
+      text += message[linkStart]
+      index = linkStart + 1
+      continue
+    }
+
+    const urlStart = labelEnd + 2
+    let urlEnd = -1
+    let parenDepth = 0
+
+    for (let urlIndex = urlStart; urlIndex < message.length; urlIndex++) {
+      const char = message[urlIndex]
+      if (char === "(") {
+        parenDepth++
+      } else if (char === ")") {
+        if (parenDepth === 0) {
+          urlEnd = urlIndex
+          break
+        }
+        parenDepth--
+      }
+    }
+
+    if (urlEnd === -1) {
+      text += message.slice(linkStart)
+      break
+    }
+
+    const source = message.slice(linkStart, urlEnd + 1)
+    const url = message.slice(urlStart, urlEnd)
+
+    if (url && !/\s/.test(url) && isValidLinkUrl(url)) {
+      const offset = text.length
+      text += label
+      entities.push({
+        type: "text_link",
+        offset,
+        length: label.length,
+        url,
+      })
+    } else {
+      text += source
+    }
+
+    index = urlEnd + 1
+  }
+
+  return { text, entities }
+}

--- a/src/components/Form/form.ts
+++ b/src/components/Form/form.ts
@@ -212,6 +212,9 @@ export class Form<T extends readonly FormInputProps[]> {
             await buttonAction.callback(this.conversation, this.ctx)
           }
         } else {
+          if ("onTextMessage" in this.input) {
+            await this.input.onTextMessage?.(this.ctx)
+          }
           await this.saveToResult(useInput || this.input.default || "")
         }
 
@@ -358,7 +361,6 @@ export class Form<T extends readonly FormInputProps[]> {
     }
   }
 }
-
 
 export function createForm<T extends readonly FormInputProps[]>(
   conversation: Conversation<MyContext>,

--- a/src/components/Form/types/formInputProps.ts
+++ b/src/components/Form/types/formInputProps.ts
@@ -1,18 +1,24 @@
 import { FORM_INPUT_TYPES } from "../enums/formInputTypes"
 import { FromInputValue } from "./formInputValue"
 import { CalendarOptions } from "telegram-inline-calendar"
+import { MyContext } from "@/common/types/myContext"
 
-export type FormInputProps = {
+type BaseFormInputProps = {
   name: string
   optional?: boolean
   values?: Array<FromInputValue>
   default?: FromInputValue
   alias?: string
   owner?: string
-} & (
-  | { type: Exclude<FORM_INPUT_TYPES, FORM_INPUT_TYPES.DATE> }
-  | {
+}
+
+export type FormInputProps =
+  | (BaseFormInputProps & {
+      type: Exclude<FORM_INPUT_TYPES, FORM_INPUT_TYPES.DATE>
+      // Runs only after a non-button text message has been accepted as input.
+      onTextMessage?: (ctx: MyContext) => void | Promise<void>
+    })
+  | (BaseFormInputProps & {
       type: FORM_INPUT_TYPES.DATE
       calendarOptions?: CalendarOptions
-    }
-)
+    })

--- a/src/components/NotificationListener/notificationListener.ts
+++ b/src/components/NotificationListener/notificationListener.ts
@@ -4,10 +4,16 @@ import { NOTIFICATION_TYPES } from "@/common/enums/notificationTypes"
 import { MyContext } from "@/common/types/myContext"
 import { SessionData } from "@/common/types/sessionData"
 import { getApiClientHeader } from "@/common/utils/getApiClientHeader"
+import {
+  offsetNotificationMessageEntities,
+  sanitizeNotificationMessageEntities,
+} from "@/common/utils/notificationMessageEntities"
+import { parseNotificationMessageLinks } from "@/common/utils/parseNotificationMessageLinks"
 import { ReplyMarkup } from "@/common/utils/replyMarkup"
 import getMenuItemBreadCrumbs from "@/components/MenuBlock/utils/getMenuItemBreadCrumbs"
 import * as MongoStorage from "@grammyjs/storage-mongodb"
 import { Collection } from "@grammyjs/storage-mongodb/dist/cjs/deps.node"
+import type { MessageEntity } from "@grammyjs/types"
 import { Api, Bot, InlineKeyboard, RawApi } from "grammy"
 import { jwtDecode } from "jwt-decode"
 import { io, Socket } from "socket.io-client"
@@ -156,16 +162,7 @@ export default class NotificationListener {
 
     switch (notification.type) {
       case NOTIFICATION_TYPES.MESSAGE:
-        message = {
-          text:
-            (notification.title
-              ? `*${ReplyMarkup.escapeForParseModeV2(notification.title)}*:` +
-                ReplyMarkup.doubleNewLine
-              : "") + ReplyMarkup.escapeForParseModeV2(notification.message),
-          options: {
-            ...ReplyMarkup.parseModeV2,
-          },
-        }
+        message = NotificationListener.buildMessageNotification(notification)
         break
 
       case NOTIFICATION_TYPES.NEW_THERAPY_REQUEST:
@@ -216,6 +213,44 @@ export default class NotificationListener {
       } catch (error) {
         console.error("Notification delivery error", error)
       }
+    }
+  }
+
+  private static buildMessageNotification(notification: NotificationDto): {
+    text: string
+    options: { [key: string]: unknown }
+  } {
+    const storedEntities = sanitizeNotificationMessageEntities(
+      notification.message,
+      notification.messageEntities
+    )
+    const body = storedEntities.length
+      ? {
+          text: notification.message || "",
+          entities: storedEntities,
+        }
+      : parseNotificationMessageLinks(notification.message)
+    const entities: Array<MessageEntity> = []
+    let text = body.text
+
+    if (notification.title) {
+      const prefix = notification.title + ":" + ReplyMarkup.doubleNewLine
+      text = prefix + body.text
+      entities.push({
+        type: "bold",
+        offset: 0,
+        length: notification.title.length,
+      })
+      entities.push(
+        ...offsetNotificationMessageEntities(body.entities, prefix.length)
+      )
+    } else {
+      entities.push(...body.entities)
+    }
+
+    return {
+      text,
+      options: entities.length ? { entities } : {},
     }
   }
 

--- a/src/conversations/notifications/create.ts
+++ b/src/conversations/notifications/create.ts
@@ -7,7 +7,9 @@ import { NOTIFICATION_TYPES } from "@/common/enums/notificationTypes"
 import { ROLES } from "@/common/enums/roles"
 import { getTextOfNotification } from "@/common/texts/getTextOfNotification"
 import { MyContext } from "@/common/types/myContext"
+import { NotificationMessageEntity } from "@/common/types/notificationMessageEntity"
 import { getDateFromRuDateString } from "@/common/utils/getDateFromRuDateString"
+import { sanitizeNotificationMessageEntities } from "@/common/utils/notificationMessageEntities"
 import { notEmpty } from "@/common/utils/notEmpty"
 import { ReplyMarkup } from "@/common/utils/replyMarkup"
 import { FORM_INPUT_TYPES } from "@/components/Form/enums/formInputTypes"
@@ -30,6 +32,7 @@ const notificationCreate: BotConversation = {
     ): Promise<ConversationResult | undefined | unknown> => {
       // NOTICE: don't use conversation.now inside of conversation.external
       const now = await conversation.now()
+      let messageEntities: Array<NotificationMessageEntity> = []
 
       const inputs = [
         {
@@ -54,6 +57,12 @@ const notificationCreate: BotConversation = {
           name: "message",
           alias: "Текст сообщение",
           type: FORM_INPUT_TYPES.STRING,
+          onTextMessage: (messageCtx: MyContext) => {
+            messageEntities = sanitizeNotificationMessageEntities(
+              messageCtx.msg?.text,
+              messageCtx.msg?.entities
+            )
+          },
         },
         {
           name: "startsAt",
@@ -94,6 +103,9 @@ const notificationCreate: BotConversation = {
               roles: [formResult.data.roles as ROLES],
               title: formResult.data.title,
               message: formResult.data.message,
+              messageEntities: messageEntities.length
+                ? messageEntities
+                : undefined,
               type: NOTIFICATION_TYPES.MESSAGE,
             })
           })


### PR DESCRIPTION
Senders typed links, the bot flattened them. Years of neglect. Now it keeps the sender's entities, parses [label](url) as a fallback, and renders with real Telegram entities — bold title included. MarkdownV2 escaping? Retired.

The best notification upgrade in bot history!