### PR TITLE
feat: /manual command — ROLE-AWARE!

### DIFF
--- a/src/common/consts/botCommands.ts
+++ b/src/common/consts/botCommands.ts
@@ -1,0 +1,12 @@
+import { BOT_COMMANDS_DESCR } from "@/common/enums/botCommandsDescr"
+import { BOT_COMMANDS } from "@/common/enums/botCommands"
+import { BotCommand } from "grammy/types"
+
+export const DEFAULT_BOT_COMMANDS: ReadonlyArray<BotCommand> = [
+  { command: BOT_COMMANDS.START, description: BOT_COMMANDS_DESCR.START },
+  { command: BOT_COMMANDS.MENU, description: BOT_COMMANDS_DESCR.MENU },
+  {
+    command: BOT_COMMANDS.REQUISITES,
+    description: BOT_COMMANDS_DESCR.REQUISITES,
+  },
+]

--- a/src/common/enums/botCommands.ts
+++ b/src/common/enums/botCommands.ts
@@ -1,6 +1,7 @@
 export enum BOT_COMMANDS {
   START = "start",
   MENU = "menu",
+  MANUAL = "manual",
   REQUISITES = "requisites",
   TERMS_AGREEMENT = "terms",
 

--- a/src/common/enums/botCommandsDescr.ts
+++ b/src/common/enums/botCommandsDescr.ts
@@ -1,6 +1,7 @@
 export enum BOT_COMMANDS_DESCR {
   START = "Запустить бота",
   MENU = "Основное меню",
+  MANUAL = "Инструкция",
   REQUISITES = "Реквизиты",
   TERMS_AGREEMENT = "Соглашение об использовании",
 

--- a/src/common/utils/manualCommand.test.ts
+++ b/src/common/utils/manualCommand.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { BOT_COMMANDS } from "@/common/enums/botCommands"
+import { ROLES } from "@/common/enums/roles"
+import { DEFAULT_BOT_COMMANDS } from "@/common/consts/botCommands"
+import {
+  EDITOR_MANUAL_LINK,
+  PSYCHOLOGIST_MANUAL_LINK,
+  hasManualCommandAccess,
+  getManualInstructionText,
+  getRoleAwareBotCommands,
+} from "./manualCommand"
+
+describe("manual command helpers", () => {
+  it("does not add manual command or instruction links without eligible roles", () => {
+    for (const role of [ROLES.USER, ROLES.ADMIN, ROLES.ACCOUNTANT]) {
+      const commands = getRoleAwareBotCommands([role])
+
+      assert.equal(hasManualCommandAccess([role]), false)
+      assert.equal(
+        commands.some(({ command }) => command === BOT_COMMANDS.MANUAL),
+        false
+      )
+      assert.equal(getManualInstructionText([role]), undefined)
+    }
+  })
+
+  it("adds manual command and editor instruction for editors", () => {
+    const commands = getRoleAwareBotCommands([ROLES.EDITOR])
+    const text = getManualInstructionText([ROLES.EDITOR])
+
+    assert.equal(
+      commands.some(({ command }) => command === BOT_COMMANDS.MANUAL),
+      true
+    )
+    assert.equal(hasManualCommandAccess([ROLES.EDITOR]), true)
+    assert.equal(text, `Инструкция для редакторов: ${EDITOR_MANUAL_LINK}`)
+    assert.equal(text?.includes(PSYCHOLOGIST_MANUAL_LINK), false)
+  })
+
+  it("adds manual command and psychologist instruction for psychologists", () => {
+    const commands = getRoleAwareBotCommands([ROLES.PSYCHOLOGIST])
+    const text = getManualInstructionText([ROLES.PSYCHOLOGIST])
+
+    assert.equal(
+      commands.some(({ command }) => command === BOT_COMMANDS.MANUAL),
+      true
+    )
+    assert.equal(hasManualCommandAccess([ROLES.PSYCHOLOGIST]), true)
+    assert.equal(
+      text,
+      `Инструкция для психологов: ${PSYCHOLOGIST_MANUAL_LINK}`
+    )
+    assert.equal(text?.includes(EDITOR_MANUAL_LINK), false)
+  })
+
+  it("adds one manual command and both instructions for users with both roles", () => {
+    const commands = getRoleAwareBotCommands([ROLES.EDITOR, ROLES.PSYCHOLOGIST])
+    const text = getManualInstructionText([ROLES.EDITOR, ROLES.PSYCHOLOGIST])
+
+    assert.equal(
+      commands.filter(({ command }) => command === BOT_COMMANDS.MANUAL).length,
+      1
+    )
+    assert.equal(
+      text,
+      [
+        `Инструкция для редакторов: ${EDITOR_MANUAL_LINK}`,
+        `Инструкция для психологов: ${PSYCHOLOGIST_MANUAL_LINK}`,
+      ].join("\r\n\r\n")
+    )
+  })
+
+  it("returns fresh command arrays without mutating the default commands", () => {
+    const ineligibleCommands = getRoleAwareBotCommands([ROLES.USER])
+    const eligibleCommands = getRoleAwareBotCommands([ROLES.EDITOR])
+    const defaultCommandsLength = DEFAULT_BOT_COMMANDS.length
+
+    ineligibleCommands.push({
+      command: BOT_COMMANDS.MANUAL,
+      description: "mutated",
+    })
+    eligibleCommands.pop()
+
+    assert.equal(DEFAULT_BOT_COMMANDS.length, defaultCommandsLength)
+    assert.equal(
+      DEFAULT_BOT_COMMANDS.some(
+        ({ command, description }) =>
+          command === BOT_COMMANDS.MANUAL && description === "mutated"
+      ),
+      false
+    )
+  })
+})

--- a/src/common/utils/manualCommand.ts
+++ b/src/common/utils/manualCommand.ts
@@ -1,0 +1,58 @@
+import { DEFAULT_BOT_COMMANDS } from "@/common/consts/botCommands"
+import { BOT_COMMANDS } from "@/common/enums/botCommands"
+import { BOT_COMMANDS_DESCR } from "@/common/enums/botCommandsDescr"
+import { ROLES } from "@/common/enums/roles"
+import { ReplyMarkup } from "@/common/utils/replyMarkup"
+import { BotCommand } from "grammy/types"
+
+export const EDITOR_MANUAL_LINK =
+  "https://docs.google.com/presentation/d/1mIkoYS-gRPEXqx_CWGsL67GhUFptuWB0M1glpc_GGo4/edit?usp=drive_link"
+
+export const PSYCHOLOGIST_MANUAL_LINK =
+  "https://docs.google.com/presentation/d/1bpbpc5ipIrwF0QZY2E4XWddTmAkz6Cg2Lb4x8UjQK00/edit?usp=drive_link"
+
+export const MANUAL_COMMAND_UNAVAILABLE_TEXT =
+  "Инструкция доступна только для редакторов и психологов."
+
+function hasRole(roles: Array<ROLES>, role: ROLES): boolean {
+  return roles.includes(role)
+}
+
+export function hasManualCommandAccess(roles: Array<ROLES> = []): boolean {
+  return hasRole(roles, ROLES.EDITOR) || hasRole(roles, ROLES.PSYCHOLOGIST)
+}
+
+export function getRoleAwareBotCommands(
+  roles: Array<ROLES> = []
+): Array<BotCommand> {
+  const commands = [...DEFAULT_BOT_COMMANDS]
+
+  if (!hasManualCommandAccess(roles)) {
+    return commands
+  }
+
+  return commands.concat([
+    {
+      command: BOT_COMMANDS.MANUAL,
+      description: BOT_COMMANDS_DESCR.MANUAL,
+    },
+  ])
+}
+
+export function getManualInstructionText(
+  roles: Array<ROLES> = []
+): string | undefined {
+  const instructions: Array<string> = []
+
+  if (hasRole(roles, ROLES.EDITOR)) {
+    instructions.push(`Инструкция для редакторов: ${EDITOR_MANUAL_LINK}`)
+  }
+
+  if (hasRole(roles, ROLES.PSYCHOLOGIST)) {
+    instructions.push(`Инструкция для психологов: ${PSYCHOLOGIST_MANUAL_LINK}`)
+  }
+
+  return instructions.length
+    ? instructions.join(ReplyMarkup.doubleNewLine)
+    : undefined
+}

--- a/src/domBot.ts
+++ b/src/domBot.ts
@@ -3,7 +3,6 @@ import * as MongoStorage from "@grammyjs/storage-mongodb"
 import { config } from "dotenv"
 import { Bot, Context, GrammyError, HttpError, session } from "grammy"
 import { BOT_COMMANDS } from "./common/enums/botCommands"
-import { BOT_COMMANDS_DESCR } from "./common/enums/botCommandsDescr"
 import { BOT_ERRORS } from "./common/enums/botErrors"
 import { BOT_TEXTS } from "./common/enums/botTexts"
 import { BotConversations } from "./conversations"
@@ -14,10 +13,17 @@ import { SessionData, defaultSessionData } from "./common/types/sessionData"
 import { DbConnection, getSessions } from "./services/db/connectDB"
 
 import { cwd } from "process"
+import { DEFAULT_BOT_COMMANDS } from "./common/consts/botCommands"
 import { apiLoginByTelegram } from "./common/middlewares/apiLoginByTelegram"
 import { PrimitiveValues } from "./common/types/primitiveValues"
 import getAvailableCommandButtons from "./common/utils/getAvailableCommandButtons"
 import getFilterByCommand from "./common/utils/getFilterByCommand"
+import {
+  MANUAL_COMMAND_UNAVAILABLE_TEXT,
+  getManualInstructionText,
+  getRoleAwareBotCommands,
+  hasManualCommandAccess,
+} from "./common/utils/manualCommand"
 import { MENU_ITEM_TYPES } from "./components/MenuBlock/enums/menuItemTypes"
 import MenuBlock from "./components/MenuBlock/menuBlock"
 import NotificationListener from "./components/NotificationListener/notificationListener"
@@ -56,18 +62,26 @@ export default domBot
 
 /** COMMANDS */
 
-domBot.api.setMyCommands([
-  { command: BOT_COMMANDS.START, description: BOT_COMMANDS_DESCR.START },
-  { command: BOT_COMMANDS.MENU, description: BOT_COMMANDS_DESCR.MENU },
-  {
-    command: BOT_COMMANDS.REQUISITES,
-    description: BOT_COMMANDS_DESCR.REQUISITES,
-  },
-  // {
-  //   command: BOT_COMMANDS.TERMS_AGREEMENT,
-  //   description: BOT_COMMANDS_DESCR.TERMS_AGREEMENT,
-  // },
-])
+domBot.api.setMyCommands(DEFAULT_BOT_COMMANDS)
+
+async function syncRoleAwareBotCommands(ctx: MyContext): Promise<void> {
+  try {
+    if (ctx.chat?.type !== "private" || !ctx.session.user) {
+      return
+    }
+
+    const roles = ctx.session.user.roles
+    const scope = { type: "chat" as const, chat_id: ctx.chat.id }
+
+    if (hasManualCommandAccess(roles)) {
+      await ctx.api.setMyCommands(getRoleAwareBotCommands(roles), { scope })
+    } else {
+      await ctx.api.deleteMyCommands({ scope })
+    }
+  } catch (error) {
+    console.error("[syncRoleAwareBotCommands] sync failed:", error)
+  }
+}
 
 /** SESSION */
 
@@ -109,6 +123,8 @@ domBot.command(BOT_COMMANDS.START, async (ctx) => {
   } catch (error) {
     console.log(BOT_ERRORS.CONVERSATION_EXIT, error)
   }
+
+  await syncRoleAwareBotCommands(ctx)
 
   await ctx.reply(BOT_TEXTS.WELCOME, {
     reply_markup: getAvailableCommandButtons(ctx.session),
@@ -184,6 +200,19 @@ domBot.command(BOT_COMMANDS.REQUISITES, async (ctx) => {
 
 domBot.command(BOT_COMMANDS.MENU, async (ctx) => {
   await ctx.conversation.enter(CONVERSATION_NAMES.SELECT_MENU_ITEM)
+})
+
+domBot.command(BOT_COMMANDS.MANUAL, async (ctx) => {
+  try {
+    await ctx.conversation.exit()
+  } catch (error) {
+    console.log(BOT_ERRORS.CONVERSATION_EXIT, error)
+  }
+
+  await ctx.reply(
+    getManualInstructionText(ctx.session.user?.roles) ||
+      MANUAL_COMMAND_UNAVAILABLE_TEXT
+  )
 })
 
 /** MESSAGE HANDLERS */

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ async function startBot() {
           clearTimeout(timeout)
           console.info("Bot was started successfully")
           if (process.send) {
-            process.send('ready')
+            process.send("ready")
           }
           resolve(runner)
         } else {


### PR DESCRIPTION
Editors and psychologists had manuals. Nobody could find them. Buried. Now /manual serves the right link to the right role — per-chat command menus, synced on /start. Everyone else? They don't even see it.

Smart. Scoped. DONE!