### PR TITLE
fix: claim FIRST, send SECOND — NO DUPLICATES!

### DIFF
--- a/src/components/NotificationListener/notificationListener.test.ts
+++ b/src/components/NotificationListener/notificationListener.test.ts
@@ -123,7 +123,7 @@ describe("NotificationListener message delivery", () => {
     ])
   })
 
-  it("marks notifications as received only after Telegram accepts the message", async () => {
+  it("claims notifications before sending them to Telegram", async () => {
     const calls: Array<string> = []
     const tokenPayload = Buffer.from(
       JSON.stringify({ userId: "user-1", roles: [] })
@@ -212,7 +212,96 @@ describe("NotificationListener message delivery", () => {
       }
     ).makeEffect(notification)
 
-    assert.deepEqual(calls, ["send", "receipt"])
+    assert.deepEqual(calls, ["receipt", "send"])
     assert.deepEqual(notification.received, ["user-1"])
+  })
+
+  it("skips Telegram delivery when the notification was already claimed", async () => {
+    const calls: Array<string> = []
+    const tokenPayload = Buffer.from(
+      JSON.stringify({ userId: "user-1", roles: [] })
+    ).toString("base64url")
+    const token = `header.${tokenPayload}.signature`
+    const notification = {
+      _id: "notification-1",
+      type: "message",
+      message: broadcastMessage,
+      messageEntities: [],
+      roles: [],
+      recipients: [],
+      received: [],
+    }
+
+    ;(
+      NotificationListener as unknown as {
+        bot: {
+          api: {
+            sendMessage: () => Promise<unknown>
+          }
+        }
+        sessions: {
+          find: () => {
+            hasNext: () => Promise<boolean>
+            next: () => Promise<unknown>
+            rewind: () => void
+          }
+        }
+        socket: {
+          emitWithAck: (message: string, data?: unknown) => Promise<boolean>
+        }
+        makeEffect: (notification: unknown) => Promise<void>
+      }
+    ).bot = {
+      api: {
+        sendMessage: async () => {
+          calls.push("send")
+          return { message_id: 1 }
+        },
+      },
+    }
+    ;(
+      NotificationListener as unknown as {
+        sessions: {
+          find: () => {
+            hasNext: () => Promise<boolean>
+            next: () => Promise<unknown>
+            rewind: () => void
+          }
+        }
+      }
+    ).sessions = {
+      find: () => {
+        let consumed = false
+        return {
+          hasNext: async () => !consumed,
+          next: async () => {
+            consumed = true
+            return { key: "bot/chat-1", value: { token } }
+          },
+          rewind: () => undefined,
+        }
+      },
+    }
+    ;(
+      NotificationListener as unknown as {
+        socket: {
+          emitWithAck: (message: string, data?: unknown) => Promise<boolean>
+        }
+      }
+    ).socket = {
+      emitWithAck: async () => {
+        calls.push("receipt")
+        return false
+      },
+    }
+
+    await (
+      NotificationListener as unknown as {
+        makeEffect: (notification: unknown) => Promise<void>
+      }
+    ).makeEffect(notification)
+
+    assert.deepEqual(calls, ["receipt"])
+    assert.deepEqual(notification.received, [])
   })
 })

--- a/src/components/NotificationListener/notificationListener.ts
+++ b/src/components/NotificationListener/notificationListener.ts
@@ -195,19 +195,18 @@ export default class NotificationListener {
 
     if (message) {
       try {
-        await NotificationListener.sendTelegramMessage(
-          recipient.chatId,
-          message
-        )
-
         const result = await NotificationListener.sendNotificationOfReceipt(
           notification._id,
           recipient.token
         )
 
         if (result) {
-          // NOTICE: important to push userId into notification.received after successful sending to avoid extra messages
+          // NOTICE: important to push userId into notification.received before sending to avoid extra messages
           notification.received.push(recipient.userId)
+          await NotificationListener.sendTelegramMessage(
+            recipient.chatId,
+            message
+          )
         }
       } catch (error) {
         console.error("Notification delivery error", error)


### PR DESCRIPTION
Send-then-claim looked safe. It wasn't. Duplicate messages were one retry away. Now the bot claims the receipt atomically and only then talks to Telegram. Claimed already? Silence.

At-most-once. Believe me!