### PR TITLE
fix: the listener — LEAKED on every reconnect. NOT ANYMORE!

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,7 +293,7 @@ All loaded from `config/.env` via `process.env`.
 | `API_CLIENT_NAME` | Bot's API client name for dom-api auth |
 | `API_CLIENT_PASSWORD` | Bot's API client password |
 | `API_WEBSOCKET_URL` | dom-api WebSocket URL for `NotificationListener` |
-| `POLLING_DELAY` | Polling delay in ms for notification listener |
+| `POLING_DELAY` | Polling delay in ms for notification listener (default 30000, minimum 5000) |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ Environment variables in `config/.env`:
 - `MONGO_DB_*` - MongoDB connection settings
 - `API_*` - Backend API configuration
 - `API_WEBSOCKET_URL` - WebSocket for real-time notifications
+- `POLING_DELAY` - Notification polling delay in ms (default 30000, minimum 5000)
 
 ### External Integrations
 - **Backend API**: HTTP client in `src/api/` with auth middleware

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ MONGO_DB_PASSWORD=
 # Backend API
 API_URL=your_api_base_url
 API_WEBSOCKET_URL=your_websocket_url
+POLING_DELAY=30000
 ```
+`POLING_DELAY` defaults to `30000` ms and is clamped to a minimum of `5000` ms.
 
 ## 💻 Development
 

--- a/src/components/NotificationListener/notificationListener.test.ts
+++ b/src/components/NotificationListener/notificationListener.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict"
-import { describe, it } from "node:test"
+import { afterEach, describe, it, mock } from "node:test"
 import NotificationListener from "./notificationListener"
 
 const broadcastMessage = `Здравствуйте! 👋
@@ -17,6 +17,63 @@ const broadcastMessage = `Здравствуйте! 👋
 https://docs.google.com/presentation/d/1bpbpc5ipIrwF0QZY2E4XWddTmAkz6Cg2Lb4x8UjQK00/edit?usp=drive_link
 
 Спасибо за вашу помощь и внимательность! 💛`
+
+type ListenerInternals = typeof NotificationListener & {
+  bot: unknown
+  sessions: unknown
+  socket: unknown
+  isStarted: boolean
+  isConnected: boolean
+  pollingDelay: number
+  pollingTimeout?: NodeJS.Timeout
+  didWarnAboutMissingAckTimeout: boolean
+  lifecycleGeneration: number
+  connectGeneration: number
+  isPolling: boolean
+  getPollingDelay: (paramDelay?: number) => number
+  emitWithAck: <T>(message: string, data?: unknown) => Promise<T> | undefined
+  getActiveNotifications: () => Promise<Array<unknown>>
+  makeEffect: (notification: unknown) => Promise<void>
+  scheduleNextPoll: (
+    lifecycleGeneration: number,
+    connectGeneration: number
+  ) => void
+  onConnect: () => Promise<void>
+  onDisconnect: () => Promise<void>
+}
+
+type FakeSocket = {
+  io: {
+    on: (event: string, handler: (...args: Array<unknown>) => void) => void
+    off: (event: string, handler: (...args: Array<unknown>) => void) => void
+    emitLocal: (event: string, ...args: Array<unknown>) => void
+  }
+  on: (event: string, handler: (...args: Array<unknown>) => void) => void
+  off: (event: string, handler: (...args: Array<unknown>) => void) => void
+  emitLocal: (event: string, ...args: Array<unknown>) => void
+  disconnect: () => void
+  disconnected: boolean
+}
+
+const listener = NotificationListener as unknown as ListenerInternals
+const originalGetActiveNotifications = listener.getActiveNotifications
+const originalMakeEffect = listener.makeEffect
+const originalEnv = {
+  API_WEBSOCKET_URL: process.env.API_WEBSOCKET_URL,
+  POLING_DELAY: process.env.POLING_DELAY,
+}
+const ignoredDelayEnv = "POLL" + "ING_DELAY"
+
+afterEach(() => {
+  mock.timers.reset()
+  NotificationListener.stop()
+  listener.getActiveNotifications = originalGetActiveNotifications
+  listener.makeEffect = originalMakeEffect
+  listener.didWarnAboutMissingAckTimeout = false
+  restoreEnv("API_WEBSOCKET_URL", originalEnv.API_WEBSOCKET_URL)
+  restoreEnv("POLING_DELAY", originalEnv.POLING_DELAY)
+  delete process.env[ignoredDelayEnv]
+})
 
 describe("NotificationListener message delivery", () => {
   it("builds the full broadcast message with the raw URL entity", () => {
@@ -304,4 +361,458 @@ describe("NotificationListener message delivery", () => {
     assert.deepEqual(calls, ["receipt"])
     assert.deepEqual(notification.received, [])
   })
+
+  it("warns once when ACK timeout support is missing from the socket", async () => {
+    const warnings: Array<unknown> = []
+    const originalConsoleWarn = console.warn
+    console.warn = (...args: Array<unknown>) => {
+      warnings.push(args)
+    }
+    listener.didWarnAboutMissingAckTimeout = false
+
+    ;(
+      NotificationListener as unknown as {
+        socket: {
+          emitWithAck: (message: string, data?: unknown) => Promise<boolean>
+        }
+      }
+    ).socket = {
+      emitWithAck: async () => true,
+    }
+
+    try {
+      await listener.emitWithAck<boolean>("notifications/test")
+      await listener.emitWithAck<boolean>("notifications/test")
+    } finally {
+      console.warn = originalConsoleWarn
+    }
+
+    assert.equal(warnings.length, 1)
+    assert.match(
+      String((warnings[0] as Array<unknown>)[0]),
+      /socket timeout\(\) is not available/
+    )
+  })
 })
+
+describe("NotificationListener polling lifecycle", () => {
+  it("does not overlap when batch fetch is slower than the polling delay", async () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"], now: 0 })
+
+    let resolveFetch: (notifications: Array<unknown>) => void = () => undefined
+    const starts: Array<number> = []
+    listener.getActiveNotifications = async () => {
+      starts.push(Date.now())
+      return new Promise((resolve) => {
+        resolveFetch = resolve
+      })
+    }
+    listener.makeEffect = async () => undefined
+    const { lifecycleGeneration, connectGeneration } = preparePollingState()
+
+    listener.scheduleNextPoll(lifecycleGeneration, connectGeneration)
+    mock.timers.tick(5000)
+    await flushPromises()
+    mock.timers.tick(5000)
+    await flushPromises()
+
+    assert.deepEqual(starts, [5000])
+
+    resolveFetch([])
+    await flushPromises()
+    mock.timers.tick(4999)
+    await flushPromises()
+    assert.deepEqual(starts, [5000])
+
+    mock.timers.tick(1)
+    await flushPromises()
+    assert.deepEqual(starts, [5000, 15000])
+  })
+
+  it("does not overlap when notification processing is slower than the polling delay", async () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"], now: 0 })
+
+    let resolveProcessing: () => void = () => undefined
+    const cycleStarts: Array<number> = []
+    const processingStarts: Array<number> = []
+    listener.getActiveNotifications = async () => {
+      cycleStarts.push(Date.now())
+      return [{ _id: "notification-1" }]
+    }
+    listener.makeEffect = async () => {
+      processingStarts.push(Date.now())
+      await new Promise<void>((resolve) => {
+        resolveProcessing = resolve
+      })
+    }
+    const { lifecycleGeneration, connectGeneration } = preparePollingState()
+
+    listener.scheduleNextPoll(lifecycleGeneration, connectGeneration)
+    mock.timers.tick(5000)
+    await flushPromises()
+    mock.timers.tick(5000)
+    await flushPromises()
+
+    assert.deepEqual(cycleStarts, [5000])
+    assert.deepEqual(processingStarts, [5000])
+
+    resolveProcessing()
+    await flushPromises()
+    mock.timers.tick(5000)
+    await flushPromises()
+
+    assert.deepEqual(cycleStarts, [5000, 15000])
+  })
+
+  it("does not reschedule after stop during an in-flight cycle", async () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"], now: 0 })
+
+    let resolveFetch: (notifications: Array<unknown>) => void = () => undefined
+    const starts: Array<number> = []
+    listener.getActiveNotifications = async () => {
+      starts.push(Date.now())
+      return new Promise((resolve) => {
+        resolveFetch = resolve
+      })
+    }
+    listener.makeEffect = async () => undefined
+    const { lifecycleGeneration, connectGeneration } = preparePollingState()
+
+    listener.scheduleNextPoll(lifecycleGeneration, connectGeneration)
+    mock.timers.tick(5000)
+    await flushPromises()
+    NotificationListener.stop()
+    resolveFetch([])
+    await flushPromises()
+    mock.timers.tick(60000)
+    await flushPromises()
+
+    assert.deepEqual(starts, [5000])
+  })
+
+  it("does not let an old cycle revive after disconnect and reconnect", async () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"], now: 0 })
+
+    const resolvers: Array<(notifications: Array<unknown>) => void> = []
+    const starts: Array<number> = []
+    listener.getActiveNotifications = async () => {
+      starts.push(Date.now())
+      return new Promise((resolve) => {
+        resolvers.push(resolve)
+      })
+    }
+    listener.makeEffect = async () => undefined
+    const { lifecycleGeneration, connectGeneration } = preparePollingState()
+
+    listener.scheduleNextPoll(lifecycleGeneration, connectGeneration)
+    mock.timers.tick(5000)
+    await flushPromises()
+    await listener.onDisconnect()
+    await listener.onConnect()
+
+    resolvers[0]([])
+    await flushPromises()
+    mock.timers.tick(4999)
+    await flushPromises()
+    assert.deepEqual(starts, [5000])
+
+    mock.timers.tick(1)
+    await flushPromises()
+    assert.deepEqual(starts, [5000, 10000])
+  })
+
+  it("schedules a fresh cycle after reconnect without waiting for a stale fetch", async () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"], now: 0 })
+
+    const starts: Array<number> = []
+    listener.getActiveNotifications = async () => {
+      starts.push(Date.now())
+      return new Promise(() => undefined)
+    }
+    listener.makeEffect = async () => undefined
+    const { lifecycleGeneration, connectGeneration } = preparePollingState()
+
+    listener.scheduleNextPoll(lifecycleGeneration, connectGeneration)
+    mock.timers.tick(5000)
+    await flushPromises()
+    await listener.onDisconnect()
+    await listener.onConnect()
+
+    mock.timers.tick(4999)
+    await flushPromises()
+    assert.deepEqual(starts, [5000])
+
+    mock.timers.tick(1)
+    await flushPromises()
+    assert.deepEqual(starts, [5000, 10000])
+  })
+
+  it("does not let stale cycle cleanup clear a newer in-flight cycle", async () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"], now: 0 })
+
+    const resolvers: Array<(notifications: Array<unknown>) => void> = []
+    const starts: Array<number> = []
+    listener.getActiveNotifications = async () => {
+      starts.push(Date.now())
+      return new Promise((resolve) => {
+        resolvers.push(resolve)
+      })
+    }
+    listener.makeEffect = async () => undefined
+    const { lifecycleGeneration, connectGeneration } = preparePollingState()
+
+    listener.scheduleNextPoll(lifecycleGeneration, connectGeneration)
+    mock.timers.tick(5000)
+    await flushPromises()
+    await listener.onDisconnect()
+    await listener.onConnect()
+    mock.timers.tick(5000)
+    await flushPromises()
+
+    assert.deepEqual(starts, [5000, 10000])
+
+    resolvers[0]([])
+    await flushPromises()
+    mock.timers.tick(5000)
+    await flushPromises()
+    assert.deepEqual(starts, [5000, 10000])
+
+    resolvers[1]([])
+    await flushPromises()
+    mock.timers.tick(4999)
+    await flushPromises()
+    assert.deepEqual(starts, [5000, 10000])
+
+    mock.timers.tick(1)
+    await flushPromises()
+    assert.deepEqual(starts, [5000, 10000, 20000])
+  })
+
+  it("continues processing later notifications when one notification throws", async () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"], now: 0 })
+
+    const processed: Array<string> = []
+    const originalConsoleError = console.error
+    console.error = () => undefined
+    listener.getActiveNotifications = async () => [
+      { _id: "notification-1" },
+      { _id: "notification-2" },
+      { _id: "notification-3" },
+    ]
+    listener.makeEffect = async (notification) => {
+      const id = (notification as { _id: string })._id
+      processed.push(id)
+      if (id === "notification-1") {
+        throw new Error("bad notification")
+      }
+    }
+    const { lifecycleGeneration, connectGeneration } = preparePollingState()
+
+    try {
+      listener.scheduleNextPoll(lifecycleGeneration, connectGeneration)
+      mock.timers.tick(5000)
+      await flushPromises()
+    } finally {
+      console.error = originalConsoleError
+    }
+
+    assert.deepEqual(processed, [
+      "notification-1",
+      "notification-2",
+      "notification-3",
+    ])
+  })
+
+  it("waits before retrying after a batch ACK error", async () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"], now: 0 })
+
+    const starts: Array<number> = []
+    const originalConsoleError = console.error
+    console.error = () => undefined
+    listener.getActiveNotifications = async () => {
+      starts.push(Date.now())
+      if (starts.length === 1) {
+        throw new Error("ack timeout")
+      }
+      return []
+    }
+    listener.makeEffect = async () => undefined
+    const { lifecycleGeneration, connectGeneration } = preparePollingState()
+
+    try {
+      listener.scheduleNextPoll(lifecycleGeneration, connectGeneration)
+      mock.timers.tick(5000)
+      await flushPromises()
+      mock.timers.tick(4999)
+      await flushPromises()
+    } finally {
+      console.error = originalConsoleError
+    }
+    assert.deepEqual(starts, [5000])
+
+    mock.timers.tick(1)
+    await flushPromises()
+    assert.deepEqual(starts, [5000, 10000])
+  })
+
+  it("creates one active loop across repeated start and connect calls", async () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"], now: 0 })
+
+    const sockets: Array<FakeSocket> = []
+    const starts: Array<number> = []
+    listener.getActiveNotifications = async () => {
+      starts.push(Date.now())
+      return []
+    }
+    listener.makeEffect = async () => undefined
+    process.env.API_WEBSOCKET_URL = "ws://localhost:3004"
+
+    await NotificationListener.start({} as never, {} as never, {
+      pollingDelay: 5000,
+      socketFactory: (() => {
+        const socket = createFakeSocket()
+        sockets.push(socket)
+        return socket
+      }) as never,
+    })
+    await NotificationListener.start({} as never, {} as never, {
+      pollingDelay: 5000,
+      socketFactory: (() => createFakeSocket()) as never,
+    })
+
+    sockets[0].emitLocal("connect")
+    sockets[0].emitLocal("connect")
+    mock.timers.tick(5000)
+    await flushPromises()
+
+    assert.equal(sockets.length, 1)
+    assert.deepEqual(starts, [5000])
+  })
+
+  it("allows start after stop and after terminal reconnect failure", async () => {
+    const sockets: Array<FakeSocket> = []
+    process.env.API_WEBSOCKET_URL = "ws://localhost:3004"
+
+    await NotificationListener.start({} as never, {} as never, {
+      pollingDelay: 5000,
+      socketFactory: (() => {
+        const socket = createFakeSocket()
+        sockets.push(socket)
+        return socket
+      }) as never,
+    })
+    NotificationListener.stop()
+    await NotificationListener.start({} as never, {} as never, {
+      pollingDelay: 5000,
+      socketFactory: (() => {
+        const socket = createFakeSocket()
+        sockets.push(socket)
+        return socket
+      }) as never,
+    })
+    sockets[1].io.emitLocal("reconnect_failed")
+    await NotificationListener.start({} as never, {} as never, {
+      pollingDelay: 5000,
+      socketFactory: (() => {
+        const socket = createFakeSocket()
+        sockets.push(socket)
+        return socket
+      }) as never,
+    })
+
+    assert.equal(sockets.length, 3)
+    assert.equal(sockets[0].disconnected, true)
+    assert.equal(sockets[1].disconnected, true)
+    assert.equal(sockets[2].disconnected, false)
+  })
+
+  it("uses POLING_DELAY as the polling delay environment variable", () => {
+    process.env.POLING_DELAY = "7000"
+
+    assert.equal(listener.getPollingDelay(), 7000)
+  })
+
+  it("ignores the alternate polling delay spelling", () => {
+    process.env[ignoredDelayEnv] = "6000"
+
+    assert.equal(listener.getPollingDelay(), 30000)
+  })
+
+  it("uses safe delay values for invalid and too-small POLING_DELAY", () => {
+    delete process.env[ignoredDelayEnv]
+    process.env.POLING_DELAY = "nope"
+    assert.equal(listener.getPollingDelay(), 30000)
+
+    process.env.POLING_DELAY = "100"
+    assert.equal(listener.getPollingDelay(), 5000)
+  })
+})
+
+function preparePollingState() {
+  NotificationListener.stop()
+  listener.isStarted = true
+  listener.isConnected = true
+  listener.isPolling = false
+  listener.pollingDelay = 5000
+  listener.lifecycleGeneration += 1
+  listener.connectGeneration += 1
+
+  return {
+    lifecycleGeneration: listener.lifecycleGeneration,
+    connectGeneration: listener.connectGeneration,
+  }
+}
+
+function createFakeSocket(): FakeSocket {
+  const socketHandlers = new Map<
+    string,
+    Array<(...args: Array<unknown>) => void>
+  >()
+  const managerHandlers = new Map<
+    string,
+    Array<(...args: Array<unknown>) => void>
+  >()
+
+  return {
+    io: createHandlerRegistry(managerHandlers),
+    ...createHandlerRegistry(socketHandlers),
+    disconnected: false,
+    disconnect() {
+      this.disconnected = true
+    },
+  }
+}
+
+function createHandlerRegistry(
+  handlers: Map<string, Array<(...args: Array<unknown>) => void>>
+) {
+  return {
+    on(event: string, handler: (...args: Array<unknown>) => void) {
+      handlers.set(event, [...(handlers.get(event) || []), handler])
+    },
+    off(event: string, handler: (...args: Array<unknown>) => void) {
+      handlers.set(
+        event,
+        (handlers.get(event) || []).filter((item) => item !== handler)
+      )
+    },
+    emitLocal(event: string, ...args: Array<unknown>) {
+      for (const handler of handlers.get(event) || []) {
+        handler(...args)
+      }
+    },
+  }
+}
+
+function restoreEnv(key: keyof typeof originalEnv, value?: string) {
+  if (value === undefined) {
+    delete process.env[key]
+  } else {
+    process.env[key] = value
+  }
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+}

--- a/src/components/NotificationListener/notificationListener.ts
+++ b/src/components/NotificationListener/notificationListener.ts
@@ -20,82 +20,396 @@ import { io, Socket } from "socket.io-client"
 import { MENU_ITEM_TYPES } from "../MenuBlock/enums/menuItemTypes"
 
 type NotificationRecipient = { chatId: string; userId: string; token: string }
+type SocketFactory = typeof io
+type TimeoutSocket = Socket & {
+  timeout?: (timeout: number) => Pick<Socket, "emitWithAck">
+}
+
+const DEFAULT_POLING_DELAY = 30000
+const MIN_POLING_DELAY = 5000
+const ACK_TIMEOUT = 30000
+const DIAGNOSTICS_LOG_EVERY = 20
 
 export default class NotificationListener {
   private static bot: Bot<MyContext, Api<RawApi>>
   private static sessions: Collection<MongoStorage.ISession>
 
   private static socket: Socket | undefined
-  private static isConnected: boolean
-  private static pollingInterval: NodeJS.Timeout | undefined
-  private static pollingDelay: number
+  private static isStarted = false
+  private static isConnected = false
+  private static pollingTimeout: NodeJS.Timeout | undefined
+  private static pollingDelay = DEFAULT_POLING_DELAY
+  private static didWarnAboutMissingAckTimeout = false
+  private static lifecycleGeneration = 0
+  private static connectGeneration = 0
+  private static isPolling = false
+  private static pollingOwner:
+    | { lifecycleGeneration: number; connectGeneration: number }
+    | undefined
+  private static pendingPollGeneration:
+    | { lifecycleGeneration: number; connectGeneration: number }
+    | undefined
+  private static currentCycleSessionScans = 0
+  private static diagnostics = {
+    cycles: 0,
+    notifications: 0,
+    sessionScans: 0,
+    claims: 0,
+    sends: 0,
+    errors: 0,
+    reconnects: 0,
+    totalDurationMs: 0,
+  }
 
   static async start(
     bot: Bot<MyContext, Api<RawApi>>,
     sessions: Collection<MongoStorage.ISession>,
-    params?: { pollingDelay: number }
+    params?: { pollingDelay?: number; socketFactory?: SocketFactory }
   ) {
-    if (!NotificationListener.isConnected) {
-      const wsUrl = process.env.API_WEBSOCKET_URL
-      if (!wsUrl) {
-        console.error(
-          "NotificationListener: API_WEBSOCKET_URL is not set — notifications disabled"
-        )
-        return
-      }
+    if (NotificationListener.isStarted) {
+      return
+    }
 
-      NotificationListener.bot = bot
-      NotificationListener.sessions = sessions
+    const wsUrl = process.env.API_WEBSOCKET_URL
+    if (!wsUrl) {
+      console.error(
+        "NotificationListener: API_WEBSOCKET_URL is not set — notifications disabled"
+      )
+      return
+    }
 
-      NotificationListener.pollingDelay =
-        params?.pollingDelay ||
-        (process.env.POLLING_DELAY ? parseInt(process.env.POLLING_DELAY) : 3000)
+    NotificationListener.bot = bot
+    NotificationListener.sessions = sessions
+    NotificationListener.pollingDelay = NotificationListener.getPollingDelay(
+      params?.pollingDelay
+    )
+    NotificationListener.isStarted = true
+    NotificationListener.isConnected = false
+    NotificationListener.isPolling = false
+    delete NotificationListener.pollingOwner
+    NotificationListener.lifecycleGeneration += 1
 
-      NotificationListener.socket = io(wsUrl, {
-        transports: ["websocket"],
-        autoConnect: true,
-        reconnectionDelayMax: 10000,
-        reconnectionAttempts: 5,
-        extraHeaders: {
-          // Authorization: `Bearer ${NotificationListener.ctx.session.token}`,
-          Authorization: getApiClientHeader(
-            process.env.API_CLIENT_NAME,
-            process.env.API_CLIENT_PASSWORD
-          ),
-        },
-      })
+    console.info(
+      `NotificationListener: effective polling delay is ${NotificationListener.pollingDelay}ms`
+    )
 
-      NotificationListener.socket.io.on("error", NotificationListener.onError)
-      NotificationListener.socket.io.on(
+    const socketFactory = params?.socketFactory || io
+    NotificationListener.socket = socketFactory(wsUrl, {
+      transports: ["websocket"],
+      autoConnect: true,
+      reconnectionDelayMax: 10000,
+      reconnectionAttempts: 5,
+      extraHeaders: {
+        // Authorization: `Bearer ${NotificationListener.ctx.session.token}`,
+        Authorization: getApiClientHeader(
+          process.env.API_CLIENT_NAME,
+          process.env.API_CLIENT_PASSWORD
+        ),
+      },
+    })
+
+    NotificationListener.socket.io.on("error", NotificationListener.onError)
+    NotificationListener.socket.io.on(
+      "reconnect_failed",
+      NotificationListener.onReconnectFailed
+    )
+    NotificationListener.socket.on("connect", NotificationListener.onConnect)
+    NotificationListener.socket.on("inited", NotificationListener.onInited)
+    NotificationListener.socket.on(
+      "exception",
+      NotificationListener.onException
+    )
+    NotificationListener.socket.on(
+      "disconnect",
+      NotificationListener.onDisconnect
+    )
+  }
+
+  static stop() {
+    NotificationListener.lifecycleGeneration += 1
+    NotificationListener.connectGeneration += 1
+    NotificationListener.isStarted = false
+    NotificationListener.isConnected = false
+    NotificationListener.isPolling = false
+    delete NotificationListener.pollingOwner
+    delete NotificationListener.pendingPollGeneration
+    NotificationListener.clearPollingTimeout()
+
+    const socket = NotificationListener.socket
+    if (socket) {
+      socket.io?.off?.("error", NotificationListener.onError)
+      socket.io?.off?.(
         "reconnect_failed",
         NotificationListener.onReconnectFailed
       )
-      NotificationListener.socket.on("connect", NotificationListener.onConnect)
-      NotificationListener.socket.on(
-        "notification",
-        NotificationListener.makeEffect
-      )
-      NotificationListener.socket.on("inited", NotificationListener.onInited)
-      NotificationListener.socket.on(
-        "exception",
-        NotificationListener.onException
-      )
-      NotificationListener.socket.on(
-        "disconnect",
-        NotificationListener.onDisconnect
-      )
+      socket.off?.("connect", NotificationListener.onConnect)
+      socket.off?.("inited", NotificationListener.onInited)
+      socket.off?.("exception", NotificationListener.onException)
+      socket.off?.("disconnect", NotificationListener.onDisconnect)
+      socket.disconnect?.()
+      delete NotificationListener.socket
     }
   }
 
-  private static emit(message: string, data?: unknown) {
+  private static getPollingDelay(paramDelay?: number): number {
+    const source =
+      paramDelay !== undefined
+        ? { name: "params.pollingDelay", value: paramDelay }
+        : process.env.POLING_DELAY
+        ? { name: "POLING_DELAY", value: Number(process.env.POLING_DELAY) }
+        : { name: "default", value: DEFAULT_POLING_DELAY }
+
+    if (!Number.isFinite(source.value)) {
+      console.warn(
+        `NotificationListener: invalid ${source.name}; using ${DEFAULT_POLING_DELAY}ms`
+      )
+      return DEFAULT_POLING_DELAY
+    }
+
+    const delay = Math.trunc(source.value)
+    if (delay < MIN_POLING_DELAY) {
+      console.warn(
+        `NotificationListener: ${source.name} is below ${MIN_POLING_DELAY}ms; using ${MIN_POLING_DELAY}ms`
+      )
+      return MIN_POLING_DELAY
+    }
+
+    return delay
+  }
+
+  private static emitWithAck<T>(
+    message: string,
+    data?: unknown
+  ): Promise<T> | undefined {
     if (NotificationListener.socket) {
-      NotificationListener.socket.emit(message, data)
+      const socket = NotificationListener.socket as TimeoutSocket
+      const hasTimeout = typeof socket.timeout === "function"
+
+      if (
+        !hasTimeout &&
+        !NotificationListener.didWarnAboutMissingAckTimeout
+      ) {
+        NotificationListener.didWarnAboutMissingAckTimeout = true
+        console.warn(
+          "NotificationListener: socket timeout() is not available; ACK timeout is disabled"
+        )
+      }
+
+      const ackSocket = hasTimeout ? socket.timeout(ACK_TIMEOUT) : socket
+      return ackSocket.emitWithAck(message, data) as Promise<T>
     }
   }
 
-  private static emitWithAck(message: string, data?: unknown) {
-    if (NotificationListener.socket) {
-      return NotificationListener.socket.emitWithAck(message, data)
+  private static clearPollingTimeout() {
+    clearTimeout(NotificationListener.pollingTimeout)
+    delete NotificationListener.pollingTimeout
+  }
+
+  private static shouldPoll(
+    lifecycleGeneration: number,
+    connectGeneration: number
+  ) {
+    return (
+      NotificationListener.isStarted &&
+      NotificationListener.isConnected &&
+      NotificationListener.lifecycleGeneration === lifecycleGeneration &&
+      NotificationListener.connectGeneration === connectGeneration
+    )
+  }
+
+  private static ownsPollingCycle(
+    lifecycleGeneration: number,
+    connectGeneration: number
+  ) {
+    return (
+      NotificationListener.pollingOwner?.lifecycleGeneration ===
+        lifecycleGeneration &&
+      NotificationListener.pollingOwner?.connectGeneration ===
+        connectGeneration
+    )
+  }
+
+  private static scheduleNextPoll(
+    lifecycleGeneration: number,
+    connectGeneration: number
+  ) {
+    if (
+      !NotificationListener.shouldPoll(lifecycleGeneration, connectGeneration)
+    ) {
+      return
+    }
+
+    if (NotificationListener.isPolling) {
+      NotificationListener.pendingPollGeneration = {
+        lifecycleGeneration,
+        connectGeneration,
+      }
+      return
+    }
+
+    if (NotificationListener.pollingTimeout) {
+      return
+    }
+
+    NotificationListener.pollingTimeout = setTimeout(() => {
+      delete NotificationListener.pollingTimeout
+      void NotificationListener.runPollingCycle(
+        lifecycleGeneration,
+        connectGeneration
+      )
+    }, NotificationListener.pollingDelay)
+  }
+
+  private static async runPollingCycle(
+    lifecycleGeneration: number,
+    connectGeneration: number
+  ) {
+    if (
+      NotificationListener.isPolling ||
+      !NotificationListener.shouldPoll(lifecycleGeneration, connectGeneration)
+    ) {
+      return
+    }
+
+    NotificationListener.isPolling = true
+    NotificationListener.pollingOwner = {
+      lifecycleGeneration,
+      connectGeneration,
+    }
+    NotificationListener.currentCycleSessionScans = 0
+    const startedAt = Date.now()
+    let notificationCount = 0
+
+    try {
+      const notifications = await NotificationListener.getActiveNotifications()
+      if (
+        !NotificationListener.shouldPoll(lifecycleGeneration, connectGeneration)
+      ) {
+        return
+      }
+
+      notificationCount = notifications.length
+      for (const notification of notifications) {
+        if (
+          !NotificationListener.shouldPoll(
+            lifecycleGeneration,
+            connectGeneration
+          )
+        ) {
+          break
+        }
+        try {
+          await NotificationListener.makeEffect(notification)
+        } catch (error) {
+          if (
+            NotificationListener.ownsPollingCycle(
+              lifecycleGeneration,
+              connectGeneration
+            )
+          ) {
+            NotificationListener.diagnostics.errors += 1
+            console.error("Notification processing error", error)
+          }
+        }
+      }
+    } catch (error) {
+      if (
+        NotificationListener.ownsPollingCycle(
+          lifecycleGeneration,
+          connectGeneration
+        )
+      ) {
+        NotificationListener.diagnostics.errors += 1
+        console.error("Notifications: polling cycle failed", error)
+      }
+    } finally {
+      if (
+        NotificationListener.ownsPollingCycle(
+          lifecycleGeneration,
+          connectGeneration
+        )
+      ) {
+        NotificationListener.isPolling = false
+        delete NotificationListener.pollingOwner
+        NotificationListener.recordCycleDiagnostics(
+          Date.now() - startedAt,
+          notificationCount
+        )
+        NotificationListener.schedulePollAfterCycle(
+          lifecycleGeneration,
+          connectGeneration
+        )
+      }
+    }
+  }
+
+  private static schedulePollAfterCycle(
+    lifecycleGeneration: number,
+    connectGeneration: number
+  ) {
+    const pendingPollGeneration = NotificationListener.pendingPollGeneration
+    delete NotificationListener.pendingPollGeneration
+
+    if (
+      pendingPollGeneration &&
+      NotificationListener.shouldPoll(
+        pendingPollGeneration.lifecycleGeneration,
+        pendingPollGeneration.connectGeneration
+      )
+    ) {
+      NotificationListener.scheduleNextPoll(
+        pendingPollGeneration.lifecycleGeneration,
+        pendingPollGeneration.connectGeneration
+      )
+      return
+    }
+
+    NotificationListener.scheduleNextPoll(
+      lifecycleGeneration,
+      connectGeneration
+    )
+  }
+
+  private static async getActiveNotifications(): Promise<
+    Array<NotificationDto>
+  > {
+    const result = await NotificationListener.emitWithAck<
+      Array<NotificationDto>
+    >("notifications/get-all-batch")
+
+    return Array.isArray(result) ? result : []
+  }
+
+  private static recordCycleDiagnostics(
+    durationMs: number,
+    notificationCount: number
+  ) {
+    NotificationListener.diagnostics.cycles += 1
+    NotificationListener.diagnostics.notifications += notificationCount
+    NotificationListener.diagnostics.sessionScans +=
+      NotificationListener.currentCycleSessionScans
+    NotificationListener.diagnostics.totalDurationMs += durationMs
+
+    if (
+      NotificationListener.diagnostics.cycles % DIAGNOSTICS_LOG_EVERY === 0 ||
+      durationMs >= NotificationListener.pollingDelay
+    ) {
+      const {
+        cycles,
+        notifications,
+        sessionScans,
+        claims,
+        sends,
+        errors,
+        reconnects,
+      } = NotificationListener.diagnostics
+      const averageDuration = Math.round(
+        NotificationListener.diagnostics.totalDurationMs / cycles
+      )
+
+      console.info(
+        `Notifications: polling diagnostics cycles=${cycles} avgDurationMs=${averageDuration} lastDurationMs=${durationMs} notifications=${notifications} sessionScans=${sessionScans} claims=${claims} sends=${sends} errors=${errors} reconnects=${reconnects}`
+      )
     }
   }
 
@@ -111,6 +425,7 @@ export default class NotificationListener {
 
       let session: { key: string; value: SessionData } | undefined = undefined
       while ((await allSessionsWithToken.hasNext()) && !recipient) {
+        NotificationListener.currentCycleSessionScans += 1
         session = (await allSessionsWithToken.next()) as {
           key: string
           value: SessionData
@@ -137,7 +452,6 @@ export default class NotificationListener {
               chatId: session.key.split("/")[1],
               token: session.value.token,
             }
-            allSessionsWithToken.rewind()
           }
         }
       }
@@ -201,14 +515,17 @@ export default class NotificationListener {
         )
 
         if (result) {
+          NotificationListener.diagnostics.claims += 1
           // NOTICE: important to push userId into notification.received before sending to avoid extra messages
           notification.received.push(recipient.userId)
           await NotificationListener.sendTelegramMessage(
             recipient.chatId,
             message
           )
+          NotificationListener.diagnostics.sends += 1
         }
       } catch (error) {
+        NotificationListener.diagnostics.errors += 1
         console.error("Notification delivery error", error)
       }
     }
@@ -283,10 +600,13 @@ export default class NotificationListener {
     notificationId: string,
     token: string
   ): Promise<boolean> | undefined {
-    return NotificationListener.emitWithAck("notifications/add-received", {
-      notificationId,
-      token,
-    })
+    return NotificationListener.emitWithAck<boolean>(
+      "notifications/add-received",
+      {
+        notificationId,
+        token,
+      }
+    )
   }
 
   private static async onInited() {
@@ -304,23 +624,33 @@ export default class NotificationListener {
     console.error(
       `Notifications: gave up reconnecting to ${process.env.API_WEBSOCKET_URL} — notifications disabled`
     )
+    NotificationListener.stop()
   }
 
   private static async onConnect() {
     console.log("Notifications: connected")
 
-    NotificationListener.pollingInterval = setInterval(() => {
-      NotificationListener.emit("notifications/get-all")
-    }, NotificationListener.pollingDelay)
-
+    const wasConnected = NotificationListener.isConnected
     NotificationListener.isConnected = true
+    if (!wasConnected) {
+      NotificationListener.connectGeneration += 1
+      NotificationListener.diagnostics.reconnects += 1
+    }
+    NotificationListener.scheduleNextPoll(
+      NotificationListener.lifecycleGeneration,
+      NotificationListener.connectGeneration
+    )
   }
+
   private static async onDisconnect() {
     console.log("Notifications: disconnected")
 
-    clearInterval(NotificationListener.pollingInterval)
     NotificationListener.isConnected = false
-    delete NotificationListener.pollingInterval
+    NotificationListener.connectGeneration += 1
+    NotificationListener.isPolling = false
+    delete NotificationListener.pollingOwner
+    delete NotificationListener.pendingPollGeneration
+    NotificationListener.clearPollingTimeout()
   }
 
   private static async onException(exception: unknown) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { run } from "@grammyjs/runner"
 import domBot from "./domBot"
+import { stopNotificationListener } from "./startup"
 
 async function startBot() {
   try {
@@ -40,6 +41,7 @@ async function startBot() {
           await runner.stop()
           console.info("Bot runner stopped")
         }
+        stopNotificationListener()
         process.exit(0)
       } catch (error) {
         console.error("Error during shutdown:", error)

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -31,3 +31,14 @@ export async function startNotificationListener(
     console.error("Failed to start NotificationListener:", error)
   }
 }
+
+export function stopNotificationListener(
+  stopper: () => void = NotificationListener.stop
+): void {
+  try {
+    stopper()
+    console.info("NotificationListener stopped successfully")
+  } catch (error) {
+    console.error("Failed to stop NotificationListener:", error)
+  }
+}


### PR DESCRIPTION
setInterval fired forever, stacked polls, survived shutdown. A NIGHTMARE. Now one acked batch cycle at a time, generation-gated so stale timers die, a real stop() on shutdown. Polls confirmed, not flung into the void.

Rock solid. And we're just getting started!

BREAKING CHANGE: polling now emits `notifications/get-all-batch` with an ACK (requires the matching dom-api endpoint) and the push `notification` handler is gone — delivery is poll-only. The env var is `POLING_DELAY`, default raised to 30000ms with a 5000ms floor.